### PR TITLE
Fix BOM handling in ByteStreamReader

### DIFF
--- a/src/FixedLengthHelper.Test/FixedLengthReaderTest.cs
+++ b/src/FixedLengthHelper.Test/FixedLengthReaderTest.cs
@@ -2,6 +2,7 @@
 using System.Text;
 using FluentAssertions;
 using Moq;
+// ReSharper disable UseAwaitUsing
 
 namespace FixedLengthHelper.Test;
 
@@ -86,6 +87,7 @@ public class FixedLengthReaderTest
 
 
     [Theory]
+    [InlineData("Sample-UTF8.txt", true)]
     [InlineData("Sample-UTF8.txt", false)]
     [InlineData("Sample-UTF8-with-BOM.txt", true)]
     public void Constructor_FromFile(string fileName, bool withBom)
@@ -94,10 +96,28 @@ public class FixedLengthReaderTest
             ? new UTF8Encoding(true) 
             : new UTF8Encoding(false);
         // Arrange
-        IFixedLengthReader reader = new FixedLengthReader(fileName, encoding);
+        using IFixedLengthReader reader = new FixedLengthReader(fileName, encoding);
 
         // Act & Assert
         reader.Read().Should().BeTrue();
+        reader.GetField(0, 5, TrimMode.TrimStart, '0').Should().Be("554");
+    }
+
+
+    [Theory]
+    [InlineData("Sample-UTF8.txt", true)]
+    [InlineData("Sample-UTF8.txt", false)]
+    [InlineData("Sample-UTF8-with-BOM.txt", true)]
+    public async Task Constructor_FromFileAsync(string fileName, bool withBom)
+    {
+        Encoding encoding = withBom
+            ? new UTF8Encoding(true)
+            : new UTF8Encoding(false);
+        // Arrange
+        using IFixedLengthReader reader = new FixedLengthReader(fileName, encoding);
+
+        // Act & Assert
+        (await reader.ReadAsync()).Should().BeTrue();
         reader.GetField(0, 5, TrimMode.TrimStart, '0').Should().Be("554");
     }
 

--- a/src/FixedLengthHelper/FixedLengthHelper.csproj
+++ b/src/FixedLengthHelper/FixedLengthHelper.csproj
@@ -10,7 +10,7 @@
 	<PropertyGroup>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<PackageId>FixedLengthHelper</PackageId>
-		<Version>1.5.0</Version>
+		<Version>1.6.0</Version>
 		<Authors>nuits.jp</Authors>
 		<Copyright>© 2024 nuits.jp</Copyright>
 		<Description>FixedLengthHelper is a library to work with fixed-length formats.</Description>


### PR DESCRIPTION
- Ensures correct behavior when the Encoding specifies BOM but the actual file does not contain BOM.
- Note: Does not handle the case where the Encoding does not specify BOM but the actual file contains BOM.